### PR TITLE
Address build errors and configure to deploy to AWS Amplify

### DIFF
--- a/amplify.yml
+++ b/amplify.yml
@@ -1,0 +1,18 @@
+version: 1
+frontend:
+  phases:
+    preBuild:
+      commands:
+        - yarn install
+    build:
+      commands:
+        - cp .env.example .env
+        - yarn run build
+  artifacts:
+    baseDirectory: .next
+    files:
+      - '**/*'
+  cache:
+    paths:
+      - .next/cache/**/*
+      - node_modules/**/*

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -31,8 +31,8 @@ export default function SimpleTransferQrCodePage() {
       <Box ref={qrRef} />
       <Container>
         This simply transfers 0.001 Devnet SOL from your wallet to a randomly
-        generated wallet. Since most people don't have Devnet SOL in their
-        wallet, we've also set it up to automatically airdrop you 2 SOL on
+        generated wallet. Since most people don&apos;t have Devnet SOL in their
+        wallet, we&apos;ve also set it up to automatically airdrop you 2 SOL on
         Devnet to make it easier to test :)
       </Container>
     </VStack>

--- a/utils/locations.ts
+++ b/utils/locations.ts
@@ -1,6 +1,6 @@
 import { Keypair, PublicKey } from "@solana/web3.js"
 
-interface Location {
+export interface Location {
   index: number
   key: PublicKey
 }


### PR DESCRIPTION
Yes. That is two things. It is easy to delete the `amplify.yml` file after merging if it is not wanted. But why not? Setting up a public tunnel to your localhost via ngrok strikes me as a really bad idea.